### PR TITLE
Addition of Enigma Type M4

### DIFF
--- a/enigma/__init__.py
+++ b/enigma/__init__.py
@@ -53,10 +53,11 @@ class Enigma:
 
         else:
             # Set Default
+            self.type = 'M3'
             self.rotors['left'] = self._rotor_types[5]
             self.rotors['middle'] = self._rotor_types[3]
             self.rotors['right'] = self._rotor_types[1]
- 
+
         if user_reflector:
             self.reflector = self._reflector_types[user_reflector]
         else:

--- a/enigma/__init__.py
+++ b/enigma/__init__.py
@@ -4,7 +4,7 @@ from . import reflector
 import logging
 
 class Enigma:
-    def __init__(self, rotor_list=[], user_reflector=None, debug='ERROR', enigma_type='M3'):
+    def __init__(self, rotor_list=[], user_reflector=None, debug='ERROR', enigma_type='default'):
         '''Enigma Machine Class based on the Enigma Model 3 ciphering machine
           
            rotor_list:     [i,k,k]   Any three non-identical numbers 1-8 for rotor choice
@@ -16,7 +16,7 @@ class Enigma:
         '''
         self.version = 'v1.1.0'
         self.isBeta = False
-        self.type   = enigma_type.upper() if enigma_type.upper() in ['M3', 'M4'] else 'M3'
+        self.type   = enigma_type.upper() if enigma_type.upper() in ['M3', 'M4'] else 'default'
         self._rotor_types = {1 : rotor.rotor_1(),
                              2 : rotor.rotor_2(),
                              3 : rotor.rotor_3(),

--- a/enigmaM3_test.py
+++ b/enigmaM3_test.py
@@ -9,7 +9,7 @@ if enigma_m3.isBeta:
 intro='''
 ===========================================
 
-  WELCOME TO THE PYTHON ENIGMA 3 ENCODER
+  WELCOME TO THE PYTHON ENIGMA M3 ENCODER
                   {}
           
            Kristian Zarebski

--- a/enigmaM4_test.py
+++ b/enigmaM4_test.py
@@ -1,0 +1,30 @@
+import enigma
+
+enigma_m4 = enigma.Enigma(debug='DEBUG', enigma_type='M4', rotor_list=[1,3,5,8])
+version = enigma_m4.version
+
+if enigma_m4.isBeta:
+   version += ' (BETA)'
+
+intro='''
+===========================================
+
+  WELCOME TO THE PYTHON ENIGMA M4 ENCODER
+                  {}
+          
+           Kristian Zarebski
+
+===========================================
+Type 'q' or 'quit' to exit.
+              
+'''.format(version)
+
+inp = ''
+
+print(intro)
+while inp not in ['quit', 'q']:
+    enigma_m4 = enigma.Enigma(debug='DEBUG', enigma_type='M4', rotor_list=[1,3,5,8])
+    enigma_m4.set_key('LEAR')
+    inp = input("INPUT: ")
+    if inp not in ['quit', 'q']:
+        print("OUTPUT: {}".format(enigma_m4.type_phrase(inp)))


### PR DESCRIPTION
The four rotor variant of the Enigma machine has now been added.
`enigma_m4 = enigma.Enigma(debug='DEBUG', enigma_type='M4', rotor_list=[1,3,5,8])`
and is used in the same manner as the M3 model this time using a four letter keyword.
If no rotor list and type is specified the default is the M3.