### PR TITLE
Common code for M3 and M4

### DIFF
--- a/enigma/__init__.py
+++ b/enigma/__init__.py
@@ -51,6 +51,9 @@ class Enigma:
             self.rotors['middle right'] = self._rotor_types[rotor_list[2]]
             self.rotors['right'] = self._rotor_types[rotor_list[3]]
 
+        elif self.type == 'CUSTOM':
+            for i, rotor_index in enumerate(rotor_list):
+                self.rotors[str(i)] = self._rotor_types[rotor_index]
         else:
             # TODO put proper exception here
             assert False, "Please specify M3 or M4"
@@ -200,16 +203,17 @@ class Enigma:
         # out_str = ' '.join(out_str[i:i+3] for i in range(0, len(out_str),3)) + fill
         return out_str
 
+    def _assert_key_length(self, key):
+        if self.type == 'M3':
+            assert len(key) == 3, "ERROR: Invalid key length!"
+        elif self.type == 'M4':
+            assert len(key) == 4, "ERROR: Invalid key length!"
+        else:
+            return
+
     def set_key(self, key):
-        assert len(key) == 3 or len(key) == 4, "ERROR: Invalid key length!"
+        self._assert_key_length(key)
         assert key.isalpha(), "ERROR: Key can only contain alphabetic characters!"
         key = key.upper()
-        if self.type == 'M3':
-            self._set_rotor('left', key[0])
-            self._set_rotor('middle', key[1])
-            self._set_rotor('right', key[2])
-        else:
-            self._set_rotor('left', key[0])
-            self._set_rotor('middle left', key[0])
-            self._set_rotor('middle right', key[1])
-            self._set_rotor('right', key[3])
+        for i, k in enumerate(self._rotor_dict_keys):
+            self._set_rotor(k, key[i])

--- a/tests/test_enigma3.py
+++ b/tests/test_enigma3.py
@@ -20,12 +20,12 @@ class TestEnigma(unittest.TestCase):
         rotor_list=strategies.lists(
             strategies.integers(min_value=1, max_value=8),
             min_size=3,
-            max_size=4),
+            max_size=12),
         reflector=strategies.sampled_from(['B', 'C']),
         key=strategies.text(
             alphabet=string.ascii_uppercase,
             min_size=3,
-            max_size=4)
+            max_size=12)
     )
     @settings(max_examples=100, min_satisfying_examples=10, timeout=10)
     @example(phrase="FORK", rotor_list=[1, 2, 3], reflector='B', key='ABC')
@@ -37,6 +37,8 @@ class TestEnigma(unittest.TestCase):
                 enigma_type = 'M3'
             elif len(rotor_list) == 4:
                 enigma_type = 'M4'
+            else:
+                enigma_type = 'CUSTOM'
 
             machine = Enigma(
                 rotor_list=rotor_list,


### PR DESCRIPTION
These commits include:
* Minor fixes
* Use of common code for M3 and M4
* Support for arbitrary number of rotors
* Improved testing (now tests between 3 and 12 rotors, and phrases of longer and shorter than 3)

HOWEVER, this does regress the use of `fill` and spaces in output (starting at line 199 in `enigma/__init__.py` of artemis-beta/master branch) since this broke tests. I could use advice for what to do here (e.g. make tests work with `fill` or leave it out).